### PR TITLE
cifsd: pass a pointer to iface name to sock_setsockopt()

### DIFF
--- a/fs/cifsd/transport_tcp.c
+++ b/fs/cifsd/transport_tcp.c
@@ -417,10 +417,10 @@ static int create_socket(struct interface *iface)
 	ksmbd_tcp_reuseaddr(ksmbd_socket);
 
 	ret = sock_setsockopt(ksmbd_socket,
-				SOL_SOCKET,
-				SO_BINDTODEVICE,
-				KERNEL_SOCKPTR(iface->name),
-				strlen(iface->name));
+			      SOL_SOCKET,
+			      SO_BINDTODEVICE,
+			      iface->name,
+			      strlen(iface->name));
 	if (ret != -ENODEV && ret < 0) {
 		ksmbd_err("Failed to set SO_BINDTODEVICE: %d\n", ret);
 		goto out_error;


### PR DESCRIPTION
transport_tcp.c:422:5: error: implicit declaration of function 'KERNEL_SOCKPTR'
   422 |     KERNEL_SOCKPTR(iface->name),

KERNEL_SOCKPTR has been removed by commit 519a8a6cf91dd ("net: Revert
"net: optimize the sockptr_t for unified kernel/user address spaces"),
pass the raw iface name pointer to sock_setsockopt() instead.

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>