### PR TITLE
cifsd: fill times in SMB2_CLOSE response

### DIFF
--- a/fs/cifsd/smb2pdu.c
+++ b/fs/cifsd/smb2pdu.c
@@ -5259,6 +5259,9 @@ int smb2_close(struct ksmbd_work *work)
 	struct smb2_close_rsp *rsp;
 	struct smb2_close_rsp *rsp_org;
 	struct ksmbd_conn *conn = work->conn;
+	struct ksmbd_file *fp;
+	struct inode *inode;
+	u64 time;
 	int err = 0;
 
 	rsp_org = RESPONSE_BUF(work);
@@ -5308,21 +5311,36 @@ int smb2_close(struct ksmbd_work *work)
 	}
 	ksmbd_debug(SMB, "volatile_id = %u\n", volatile_id);
 
-	err = ksmbd_close_fd(work, volatile_id);
-	if (err)
-		goto out;
-
 	rsp->StructureSize = cpu_to_le16(60);
 	rsp->Flags = 0;
 	rsp->Reserved = 0;
-	rsp->CreationTime = 0;
-	rsp->LastAccessTime = 0;
-	rsp->LastWriteTime = 0;
-	rsp->ChangeTime = 0;
 	rsp->AllocationSize = 0;
 	rsp->EndOfFile = 0;
 	rsp->Attributes = 0;
 
+	fp = ksmbd_lookup_fd_fast(work, volatile_id);
+	if (!fp) {
+		err = -ENOENT;
+		goto out;
+	}
+
+	inode = FP_INODE(fp);
+	rsp->StructureSize = cpu_to_le16(60);
+	rsp->Flags = 0;
+	rsp->Reserved = 0;
+	rsp->CreationTime = cpu_to_le32(fp->create_time);
+	time = ksmbd_UnixTimeToNT(inode->i_atime);
+	rsp->LastAccessTime = cpu_to_le64(time);
+	time = ksmbd_UnixTimeToNT(inode->i_mtime);
+	rsp->LastWriteTime = cpu_to_le64(time);
+	time = ksmbd_UnixTimeToNT(inode->i_ctime);
+	rsp->ChangeTime = cpu_to_le64(time);
+	rsp->AllocationSize = 0;
+	rsp->EndOfFile = 0;
+	rsp->Attributes = 0;
+	ksmbd_fd_put(work, fp);
+
+	err = ksmbd_close_fd(work, volatile_id);
 out:
 	if (err) {
 		if (rsp->hdr.Status == 0)


### PR DESCRIPTION
Description for this pull request:
- Fix some of xfstests tests failures when actimeo=0 mount option is not used in local.config of xfstests.