### PR TITLE
Cifsd fixes

### DIFF
--- a/fs/cifsd/smb2pdu.c
+++ b/fs/cifsd/smb2pdu.c
@@ -2988,6 +2988,14 @@ int smb2_open(struct ksmbd_work *work)
 		need_truncate = 1;
 	}
 
+	/* fp should be searchable through ksmbd_inode.m_fp_list
+	 * after daccess, saccess, attrib_only, and stream are
+	 * initialized.
+	 */
+	write_lock(&fp->f_ci->m_lock);
+	list_add(&fp->node, &fp->f_ci->m_fp_list);
+	write_unlock(&fp->f_ci->m_lock);
+
 	generic_fillattr(d_inode(path.dentry), &stat);
 
 	/* Check delete pending among previous fp before oplock break */

--- a/fs/cifsd/smb2pdu.c
+++ b/fs/cifsd/smb2pdu.c
@@ -7758,7 +7758,7 @@ static void smb20_oplock_break_ack(struct ksmbd_work *work)
 	}
 
 	if (opinfo->op_state == OPLOCK_STATE_NONE) {
-		ksmbd_err("unexpected oplock state 0x%x\n", opinfo->op_state);
+		ksmbd_debug(SMB, "unexpected oplock state 0x%x\n", opinfo->op_state);
 		rsp->hdr.Status = STATUS_UNSUCCESSFUL;
 		goto err_out;
 	}

--- a/fs/cifsd/vfs.c
+++ b/fs/cifsd/vfs.c
@@ -1066,27 +1066,23 @@ int ksmbd_vfs_fqar_lseek(struct ksmbd_file *fp, loff_t start, loff_t length,
 	*out_count = 0;
 	end = start + length;
 	while (start < end && *out_count < in_count) {
-		ret = extent_start = f->f_op->llseek(f, start, SEEK_DATA);
-		if (ret < 0) {
-			if (ret == -ENXIO)
-				ret = 0;
+		extent_start = f->f_op->llseek(f, start, SEEK_DATA);
+		if (extent_start < 0) {
+			if (extent_start != -ENXIO)
+				ret = (int)extent_start;
 			break;
 		}
-		ret = 0;
 
 		if (extent_start >= end)
 			break;
 
-		ret = extent_end = f->f_op->llseek(f, extent_start, SEEK_HOLE);
-		if (ret < 0) {
-			if (ret == -ENXIO)
-				ret = 0;
+		extent_end = f->f_op->llseek(f, extent_start, SEEK_HOLE);
+		if (extent_end < 0) {
+			if (extent_end != -ENXIO)
+				ret = (int)extent_end;
 			break;
-		} else if (extent_start >= extent_end) {
-			ret = 0;
+		} else if (extent_start >= extent_end)
 			break;
-		}
-		ret = 0;
 
 		ranges[*out_count].file_offset = cpu_to_le64(extent_start);
 		ranges[(*out_count)++].length =

--- a/fs/cifsd/vfs_cache.c
+++ b/fs/cifsd/vfs_cache.c
@@ -641,10 +641,6 @@ struct ksmbd_file *ksmbd_open_fd(struct ksmbd_work *work,
 		return ERR_PTR(ret);
 	}
 
-	write_lock(&fp->f_ci->m_lock);
-	list_add(&fp->node, &fp->f_ci->m_fp_list);
-	write_unlock(&fp->f_ci->m_lock);
-
 	atomic_inc(&work->conn->stats.open_files_count);
 	return fp;
 }


### PR DESCRIPTION
Description for this pull request:
 - Downgrade a misleading message to debug message.
 - Fix generic/464 failure on life test. (`getfile`: Device or resource Busy. error)
 - Fix smb2 ioctl failures when running generic/476 test.