### PR TITLE
Cifsd fixes

### DIFF
--- a/fs/cifsd/oplock.c
+++ b/fs/cifsd/oplock.c
@@ -69,8 +69,17 @@ static void lease_del_list(struct oplock_info *opinfo)
 {
 	struct lease_table *lb = opinfo->o_lease->l_lb;
 
+	if (!lb)
+		return;
+
 	spin_lock(&lb->lb_lock);
-	list_del_rcu(&opinfo->lease_entry);
+	if (list_empty(&opinfo->lease_entry)) {
+		spin_unlock(&lb->lb_lock);
+		return;
+	}
+
+	list_del_init(&opinfo->lease_entry);
+	opinfo->o_lease->l_lb = NULL;
 	spin_unlock(&lb->lb_lock);
 }
 
@@ -175,8 +184,11 @@ static void opinfo_del(struct oplock_info *opinfo)
 {
 	struct ksmbd_inode *ci = opinfo->o_fp->f_ci;
 
-	if (opinfo->is_lease)
+	if (opinfo->is_lease) {
+		write_lock(&lease_list_lock);
 		lease_del_list(opinfo);
+		write_unlock(&lease_list_lock);
+	}
 	write_lock(&ci->m_lock);
 	list_del_rcu(&opinfo->op_entry);
 	write_unlock(&ci->m_lock);

--- a/fs/cifsd/smb2pdu.c
+++ b/fs/cifsd/smb2pdu.c
@@ -5665,7 +5665,9 @@ static int set_file_basic_info(struct ksmbd_file *fp,
 			ksmbd_err("can't change a file to a directory\n");
 			return -EINVAL;
 		}
-		fp->f_ci->m_fattr = file_info->Attributes;
+
+		if (!(S_ISDIR(inode->i_mode) && file_info->Attributes == ATTR_NORMAL_LE))
+			fp->f_ci->m_fattr = file_info->Attributes;
 	}
 
 	if (test_share_config_flag(share, KSMBD_SHARE_FLAG_STORE_DOS_ATTRS) &&

--- a/fs/cifsd/smb2pdu.c
+++ b/fs/cifsd/smb2pdu.c
@@ -5706,8 +5706,11 @@ static int set_file_basic_info(struct ksmbd_file *fp,
 		if (rc)
 			return -EINVAL;
 
+		inode_lock(inode);
 		setattr_copy(inode, &attrs);
-		mark_inode_dirty(inode);
+		attrs.ia_valid &= ~ATTR_CTIME;
+		rc = notify_change(dentry, &attrs, NULL);
+		inode_unlock(inode);
 	}
 	return 0;
 }

--- a/fs/cifsd/vfs.c
+++ b/fs/cifsd/vfs.c
@@ -1913,7 +1913,9 @@ int ksmbd_vfs_set_init_posix_acl(struct inode *inode)
 	int rc;
 
 	ksmbd_debug(SMB, "Set posix acls\n");
-	init_acl_state(&acl_state, 1);
+	rc = init_acl_state(&acl_state, 1);
+	if (rc)
+		return rc;
 
 	/* Set default owner group */
 	acl_state.owner.allow = (inode->i_mode & 0700) >> 6;

--- a/fs/cifsd/vfs.c
+++ b/fs/cifsd/vfs.c
@@ -1928,8 +1928,10 @@ int ksmbd_vfs_set_init_posix_acl(struct inode *inode)
 	acl_state.mask.allow = 0x07;
 
 	acls = ksmbd_vfs_posix_acl_alloc(6, GFP_KERNEL);
-	if (!acls)
+	if (!acls) {
+		free_acl_state(&acl_state);
 		return -ENOMEM;
+	}
 	posix_state_to_acl(&acl_state, acls->a_entries);
 	rc = ksmbd_vfs_set_posix_acl(inode, ACL_TYPE_ACCESS, acls);
 	if (rc < 0)


### PR DESCRIPTION
Description for this pull request:
 - Fix kernel oops from fuse+ntfs driver.
 - Fix the issue of change the directory to the file using Nautilus
   client.
 - Fix ksmbd build break with the latest linux-5.12-rc1.
 - Fix potential memleak and use after free.
 - Fix use after free from KASAN(racy issue)