### PR TITLE
cifsd-fixes

### DIFF
--- a/Documentation/filesystems/cifs/cifsd.rst
+++ b/Documentation/filesystems/cifs/cifsd.rst
@@ -67,7 +67,8 @@ CIFSD Feature Status
 Feature name                   Status
 ============================== =================================================
 Dialects                       Supported. SMB2.1 SMB3.0, SMB3.1.1 dialects
-                               excluding security vulnerable SMB1.
+                               (intentionally excludes security vulnerable SMB1
+                               dialect).
 Auto Negotiation               Supported.
 Compound Request               Supported.
 Oplock Cache Mechanism         Supported.
@@ -79,26 +80,37 @@ HMAC-SHA256 Signing            Supported.
 Secure negotiate               Supported.
 Signing Update                 Supported.
 Pre-authentication integrity   Supported.
-SMB3 encryption(CCM, GCM)      Supported.
-SMB direct(RDMA)               Partial Supported. SMB3 Multi-channel is required
-                               to connect to Windows client.
+SMB3 encryption(CCM, GCM)      Supported. (CCM and GCM128 supported, GCM256 in
+                               progress)
+SMB direct(RDMA)               Partially Supported. SMB3 Multi-channel is
+                               required to connect to Windows client.
 SMB3 Multi-channel             In Progress.
 SMB3.1.1 POSIX extension       Supported.
-ACLs                           Partial Supported. only DACLs available, SACLs is
-                               planned for future. ksmbd generate random subauth
+ACLs                           Partially Supported. only DACLs available, SACLs
+                               (auditing) is planned for the future. For
+                               ownership (SIDs) ksmbd generates random subauth
                                values(then store it to disk) and use uid/gid
                                get from inode as RID for local domain SID.
                                The current acl implementation is limited to
                                standalone server, not a domain member.
+                               Integration with Samba tools is being worked on
+                               to allow future support for running as a domain
+                               member.
 Kerberos                       Supported.
 Durable handle v1,v2           Planned for future.
 Persistent handle              Planned for future.
 SMB2 notify                    Planned for future.
 Sparse file support            Supported.
-DCE/RPC support                Partial Supported. a few calls(NetShareEnumAll,
-                               NetServerGetInfo, SAMR, LSARPC) that needed as
-                               file server via netlink interface from
-                               ksmbd.mountd.
+DCE/RPC support                Partially Supported. a few calls(NetShareEnumAll,
+                               NetServerGetInfo, SAMR, LSARPC) that are needed
+                               for file server handled via netlink interface
+                               from ksmbd.mountd. Additional integration with
+                               Samba tools and libraries via upcall is being
+                               investigated to allow support for additional
+                               DCE/RPC management calls (and future support
+                               for Witness protocol e.g.)
+ksmbd/nfsd interoperability    Planned for future. The features that ksmbd
+                               support are Leases, Notify, ACLs and Share modes.
 ============================== =================================================
 
 

--- a/fs/cifsd/smb2pdu.c
+++ b/fs/cifsd/smb2pdu.c
@@ -4793,6 +4793,24 @@ static int smb2_get_info_sec(struct ksmbd_work *work,
 	int addition_info = le32_to_cpu(req->AdditionalInformation);
 	int rc;
 
+	if (addition_info & ~(OWNER_SECINFO | GROUP_SECINFO | DACL_SECINFO)) {
+		ksmbd_debug(SMB, "Unsupported addition info: 0x%x)\n",
+			addition_info);
+
+		pntsd->revision = cpu_to_le16(1);
+		pntsd->type = cpu_to_le16(SELF_RELATIVE | DACL_PROTECTED);
+		pntsd->osidoffset = 0;
+		pntsd->gsidoffset = 0;
+		pntsd->sacloffset = 0;
+		pntsd->dacloffset = 0;
+
+		secdesclen = sizeof(struct smb_ntsd);
+		rsp->OutputBufferLength = cpu_to_le32(secdesclen);
+		inc_rfc1001_len(rsp_org, secdesclen);
+
+		return 0;
+	}
+
 	if (work->next_smb2_rcv_hdr_off) {
 		if (!HAS_FILE_ID(le64_to_cpu(req->VolatileFileId))) {
 			ksmbd_debug(SMB, "Compound request set FID = %u\n",

--- a/fs/cifsd/smb2pdu.c
+++ b/fs/cifsd/smb2pdu.c
@@ -5232,11 +5232,6 @@ out:
 	return rc;
 }
 
-static bool is_attributes_write_allowed(struct ksmbd_file *fp)
-{
-	return fp->daccess & FILE_WRITE_ATTRIBUTES_LE;
-}
-
 static int set_file_basic_info(struct ksmbd_file *fp, char *buf,
 		struct ksmbd_share_config *share)
 {
@@ -5247,7 +5242,7 @@ static int set_file_basic_info(struct ksmbd_file *fp, char *buf,
 	struct inode *inode;
 	int rc;
 
-	if (!is_attributes_write_allowed(fp))
+	if (!(fp->daccess & FILE_WRITE_ATTRIBUTES_LE))
 		return -EACCES;
 
 	file_info = (struct smb2_file_all_info *)buf;

--- a/fs/cifsd/smb2pdu.c
+++ b/fs/cifsd/smb2pdu.c
@@ -5347,7 +5347,7 @@ static int set_file_allocation_info(struct ksmbd_work *work,
 	struct inode *inode;
 	int rc;
 
-	if (!is_attributes_write_allowed(fp))
+	if (!(fp->daccess & FILE_WRITE_DATA_LE))
 		return -EACCES;
 
 	file_alloc_info = (struct smb2_file_alloc_info *)buf;
@@ -5391,7 +5391,7 @@ static int set_end_of_file_info(struct ksmbd_work *work, struct ksmbd_file *fp,
 	struct inode *inode;
 	int rc;
 
-	if (!is_attributes_write_allowed(fp))
+	if (!(fp->daccess & FILE_WRITE_DATA_LE))
 		return -EACCES;
 
 	file_eof_info = (struct smb2_file_eof_info *)buf;


### PR DESCRIPTION
Description for this pull request:
 - fix wrong desired access check in set_file_allocation_info() and set_end_of_file_info()
 - add exception check for unsupported addition info in smb2_get_info_sec().