### PR TITLE
smb: client: ensure open_cached_dir_by_dentry() only returns valid cfid

### DIFF
--- a/fs/smb/client/inode.c
+++ b/fs/smb/client/inode.c
@@ -2691,7 +2691,7 @@ cifs_dentry_needs_reval(struct dentry *dentry)
 		return true;
 
 	if (!open_cached_dir_by_dentry(tcon, dentry->d_parent, &cfid)) {
-		if (cfid->time && cifs_i->time > cfid->time) {
+		if (cifs_i->time > cfid->time) {
 			close_cached_dir(cfid);
 			return false;
 		}


### PR DESCRIPTION
open_cached_dir_by_dentry() was exposing an invalid cached directory to callers. The validity check outside the function was exclusively based on cfid->time.

Add validity check before returning success and introduce is_valid_cached_dir() helper for consistent checks across the code.

Also return -ENOENT early if dentry is NULL.