### PR TITLE
smb: client: get rid of d_drop() in cifs_do_rename()

### DIFF
--- a/fs/smb/client/inode.c
+++ b/fs/smb/client/inode.c
@@ -2484,11 +2484,8 @@ cifs_do_rename(const unsigned int xid, struct dentry *from_dentry,
 	}
 #endif /* CONFIG_CIFS_ALLOW_INSECURE_LEGACY */
 do_rename_exit:
-	if (rc == 0) {
+	if (rc == 0)
 		d_move(from_dentry, to_dentry);
-		/* Force a new lookup */
-		d_drop(from_dentry);
-	}
 	cifs_put_tlink(tlink);
 	return rc;
 }


### PR DESCRIPTION
There is no need to force a lookup by unhashing the moved dentry after successfully renaming the file on server.  The file metadata will be re-fetched from server, if necessary, in the next call to ->d_revalidate() anyways.


Cc: stable@vger.kernel.org
Cc: David Howells <dhowells@redhat.com>
Cc: linux-cifs@vger.kernel.org