### PR TITLE
smb3 client: add missing tracepoint for unsupported ioctls

### DIFF
--- a/fs/smb/client/ioctl.c
+++ b/fs/smb/client/ioctl.c
@@ -588,6 +588,9 @@ long cifs_ioctl(struct file *filep, unsigned int command, unsigned long arg)
 			break;
 		default:
 			cifs_dbg(FYI, "unsupported ioctl\n");
+			trace_smb3_unsupported_ioctl(xid,
+				pSMBFile ? pSMBFile->fid.persistent_fid : 0,
+				command);
 			break;
 	}
 cifs_ioc_exit:

--- a/fs/smb/client/trace.h
+++ b/fs/smb/client/trace.h
@@ -1579,6 +1579,7 @@ DEFINE_EVENT(smb3_ioctl_class, smb3_##name,  \
 	TP_ARGS(xid, fid, command))
 
 DEFINE_SMB3_IOCTL_EVENT(ioctl);
+DEFINE_SMB3_IOCTL_EVENT(unsupported_ioctl);
 
 DECLARE_EVENT_CLASS(smb3_shutdown_class,
 	TP_PROTO(__u32 flags,


### PR DESCRIPTION
In debugging a recent problem with an xfstest, noticed that we weren't tracing cases where the ioctl was not supported.  Add dynamic tracepoint:
    "trace-cmd record -e smb3_unsupported_ioctl"
and then after running an app which calls unsupported ioctl, "trace-cmd show"would display e.g.
      xfs_io-7289    [012] .....  1205.137765: smb3_unsupported_ioctl: xid=19 fid=0x4535bb84 ioctl cmd=0x801c581f