### PR TITLE
smb/client: ensure smb2_mapping_table rebuild on cmd changes

### DIFF
--- a/fs/smb/client/Makefile
+++ b/fs/smb/client/Makefile
@@ -48,8 +48,8 @@ cifs-$(CONFIG_CIFS_COMPRESSION) += compress.o compress/lz77.o
 # Build the SMB2 error mapping table from smb2status.h
 #
 $(obj)/smb2_mapping_table.c: $(src)/../common/smb2status.h \
-			    $(src)/gen_smb2_mapping
-	$(call cmd,gen_smb2_mapping)
+			     $(src)/gen_smb2_mapping FORCE
+	$(call if_changed,gen_smb2_mapping)
 
 $(obj)/smb2maperror.o: $(obj)/smb2_mapping_table.c
 
@@ -58,4 +58,5 @@ quiet_cmd_gen_smb2_mapping = GEN     $@
 
 obj-$(CONFIG_SMB_KUNIT_TESTS) += smb2maperror_test.o
 
-clean-files	+= smb2_mapping_table.c
+# Let Kbuild handle tracking and cleaning
+targets += smb2_mapping_table.c


### PR DESCRIPTION
The current rule for smb2_mapping_table.c uses `$(call cmd,...)`, which fails to track command line modifications in the Makefile (e.g., modifying the command to `perl -d` or `perl -w` for debug will not trigger a rebuild) and does not generate the required .cmd file for Kbuild.

Fix this by transitioning to the standard `$(call if_changed,...)` macro. This includes adding the `FORCE` prerequisite and appending the output file to the `targets` variable so Kbuild can track it properly.

As a result, Kbuild now automatically handles the cleaning of the generated file, allowing us to safely drop the redundant `clean-files` assignment.

Fixes: c527e13a7a66 ("cifs: Autogenerate SMB2 error mapping table")

Reviewed-by: ChenXiaoSong <chenxiaosong@kylinos.cn>