### PR TITLE
fs/smb/client: add verbose error logging for UNC parsing

### DIFF
--- a/fs/smb/client/fs_context.c
+++ b/fs/smb/client/fs_context.c
@@ -658,13 +658,17 @@ smb3_parse_devname(const char *devname, struct smb3_fs_context *ctx)
 
 	/* make sure we have a valid UNC double delimiter prefix */
 	len = strspn(devname, delims);
-	if (len != 2)
+	if (len != 2) {
+		cifs_dbg(VFS, "UNC: path must begin with // or \\\\\n");
 		return -EINVAL;
+	}
 
 	/* find delimiter between host and sharename */
 	pos = strpbrk(devname + 2, delims);
-	if (!pos)
+	if (!pos) {
+		cifs_dbg(VFS, "UNC: missing delimiter between hostname and share name\n");
 		return -EINVAL;
+	}
 
 	/* record the server hostname */
 	kfree(ctx->server_hostname);
@@ -677,8 +681,10 @@ smb3_parse_devname(const char *devname, struct smb3_fs_context *ctx)
 
 	/* now go until next delimiter or end of string */
 	len = strcspn(pos, delims);
-	if (!len)
+	if (!len) {
+		cifs_dbg(VFS, "UNC: missing share name\n");
 		return -EINVAL;
+	}
 
 	/* move "pos" up to delimiter or NULL */
 	pos += len;


### PR DESCRIPTION
Add cifs_dbg(VFS, ...) statements to smb3_parse_devname() to provide explicit feedback when parsing fails. Currently, the function returns -EINVAL silently, making it difficult to debug mount failures caused by malformed paths or missing share names.