### PR TITLE
smb: client: Fix integer underflow in receive_encrypted_read()

### DIFF
--- a/fs/smb/client/smb2ops.c
+++ b/fs/smb/client/smb2ops.c
@@ -4943,6 +4943,14 @@ receive_encrypted_read(struct TCP_Server_Info *server, struct mid_q_entry **mid,
 		goto free_dw;
 	server->total_read += rc;
 
+	if (le32_to_cpu(tr_hdr->OriginalMessageSize) <
+	    server->vals->read_rsp_size) {
+		cifs_server_dbg(VFS, "OriginalMessageSize %u too small for read response (%u)\n",
+			le32_to_cpu(tr_hdr->OriginalMessageSize),
+			server->vals->read_rsp_size);
+		rc = -EINVAL;
+		goto free_dw;
+	}
 	len = le32_to_cpu(tr_hdr->OriginalMessageSize) -
 		server->vals->read_rsp_size;
 	dw->len = len;


### PR DESCRIPTION
In receive_encrypted_read(), the length of data to read from the socket is computed as:

  len = le32_to_cpu(tr_hdr->OriginalMessageSize) -
        server->vals->read_rsp_size;

OriginalMessageSize comes from the server's transform header and is untrusted. If a malicious server sends a value smaller than read_rsp_size (sizeof(struct smb2_read_rsp), ~80 bytes), the unsigned subtraction wraps to a very large value (~4GB). This value is then passed to netfs_alloc_folioq_buffer() and cifs_read_iter_from_socket(), causing either:
  - A massive allocation attempt that fails with -ENOMEM (DoS)
  - Under extreme memory pressure, potential heap corruption

The existing validation in smb3_receive_transform() only checks that pdu_length >= orig_len + sizeof(transform_hdr), which does not prevent orig_len from being smaller than read_rsp_size.

Fix this by adding a check that OriginalMessageSize is at least read_rsp_size before the subtraction.