### PR TITLE
smb: client: fix OOB read in smb2_ioctl_query_info QUERY_INFO path

### DIFF
--- a/fs/smb/client/smb2ops.c
+++ b/fs/smb/client/smb2ops.c
@@ -1783,6 +1783,12 @@ replay_again:
 		qi_rsp = (struct smb2_query_info_rsp *)rsp_iov[1].iov_base;
 		if (le32_to_cpu(qi_rsp->OutputBufferLength) < qi.input_buffer_length)
 			qi.input_buffer_length = le32_to_cpu(qi_rsp->OutputBufferLength);
+		if (qi.input_buffer_length > 0 &&
+		    sizeof(struct smb2_query_info_rsp) + qi.input_buffer_length
+		    > rsp_iov[1].iov_len) {
+			rc = -EFAULT;
+			goto out;
+		}
 		if (copy_to_user(&pqi->input_buffer_length,
 				 &qi.input_buffer_length,
 				 sizeof(qi.input_buffer_length))) {


### PR DESCRIPTION
Another client side from my clanker. smb2_ioctl_query_info() has two response-copy branches: PASSTHRU_FSCTL and the default QUERY_INFO path. The FSCTL branch validates that the server-reported output length fits within the response iov:

    if (qi.input_buffer_length > 0 &&
        le32_to_cpu(io_rsp->OutputOffset) + qi.input_buffer_length
        > rsp_iov[1].iov_len)

The QUERY_INFO branch has no equivalent check:

    qi_rsp = (struct smb2_query_info_rsp *)rsp_iov[1].iov_base;
    if (le32_to_cpu(qi_rsp->OutputBufferLength) < qi.input_buffer_length)
        qi.input_buffer_length = le32_to_cpu(qi_rsp->OutputBufferLength);
    ...
    copy_to_user(pqi + 1, qi_rsp->Buffer, qi.input_buffer_length)

A malicious server can set OutputBufferLength larger than the actual response, causing copy_to_user to read past the slab allocation into adjacent kernel heap.

Reproduced under UML + KASAN by constructing a 73-byte response (sizeof(struct smb2_query_info_rsp) + 1) with OutputBufferLength=2, forcing a read 1 byte past the allocation:

  BUG: KASAN: slab-out-of-bounds in _nfs4_do_fsinfo
  Read of size 1 at addr ... by task mount.nfs4/219

Confirmed rejection without splat after patch applied.

Add the same bounds check used by the FSCTL branch.

Fixes: 5242fcb706cb ("cifs: fix bi-directional fsctl passthrough calls")
Cc: stable@vger.kernel.org
Assisted-by: Claude:claude-opus-4-6