### PR TITLE
smb: client: fix NULL pointer dereference in smb2_compound_op

### DIFF
--- a/fs/smb/client/smb2inode.c
+++ b/fs/smb/client/smb2inode.c
@@ -552,7 +552,13 @@ replay_again:
 
 finished:
 	num_rqst = 0;
-	SMB2_open_free(&rqst[num_rqst++]);
+	/*
+	 * If cfile was passed, the open was skipped; check rq_iov
+	 * to ensure we don't try to dereference a NULL pointer.
+	 */
+	if (rqst[num_rqst].rq_iov)
+		SMB2_open_free(&rqst[num_rqst]);
+	num_rqst++;
 	if (rc == -EREMCHG) {
 		pr_warn_once("server share %s deleted\n", tcon->tree_name);
 		tcon->need_reconnect = true;


### PR DESCRIPTION
When a valid cfile is passed to smb2_compound_op, the code uses a goto to jump to the 'after_open' label. This bypasses the initialization of rqst[0] by SMB2_open_init().

However, the 'finished' cleanup block unconditionally attempts to call SMB2_open_free() on rqst[0]. If SMB2_open_init() was skipped, rqst[0].rq_iov is NULL, leading to a NULL pointer dereference.

Check for a valid rq_iov before attempting to free the request to prevent the crash in handle-reuse scenarios.