### PR TITLE
smb/client: fix possible infinite loop and oob read in symlink_data()

### DIFF
--- a/fs/smb/client/smb2file.c
+++ b/fs/smb/client/smb2file.c
@@ -31,7 +31,7 @@ static struct smb2_symlink_err_rsp *symlink_data(const struct kvec *iov)
 	u32 len;
 
 	if (err->ErrorContextCount) {
-		struct smb2_error_context_rsp *p;
+		struct smb2_error_context_rsp *p, *next;
 
 		len = (u32)err->ErrorContextCount * (offsetof(struct smb2_error_context_rsp,
 							      ErrorContextData) +
@@ -49,7 +49,10 @@ static struct smb2_symlink_err_rsp *symlink_data(const struct kvec *iov)
 				 __func__, le32_to_cpu(p->ErrorId));
 
 			len = ALIGN(le32_to_cpu(p->ErrorDataLength), 8);
-			p = (struct smb2_error_context_rsp *)(p->ErrorContextData + len);
+			next = (struct smb2_error_context_rsp *)(p->ErrorContextData + len);
+			if (next <= p)
+				return ERR_PTR(-EINVAL);
+			p = next;
 		}
 	} else if (le32_to_cpu(err->ByteCount) >= sizeof(*sym) &&
 		   iov->iov_len >= SMB2_SYMLINK_STRUCT_SIZE) {


### PR DESCRIPTION
On 32-bit architectures, the infinite loop is as follows:

  len = p->ErrorDataLength == 0xfffffff8
  u8 *next = p->ErrorContextData + len
  next == p

On 32-bit architectures, the out-of-bounds read is as follows:

  len = p->ErrorDataLength == 0xfffffff0
  u8 *next = p->ErrorContextData + len
  next == (u8 *)p - 8

Reported-by: ChenXiaoSong <chenxiaosong@kylinos.cn>
Fixes: 76894f3e2f71 ("cifs: improve symlink handling for smb2+")
Cc: stable@vger.kernel.org

Reviewed-by: ChenXiaoSong <chenxiaosong@kylinos.cn>