### PR TITLE
smb: client: detect short folioq copy in cifs_copy_folioq_to_iter()

### DIFF
--- a/fs/smb/client/smb2ops.c
+++ b/fs/smb/client/smb2ops.c
@@ -4696,9 +4696,15 @@ cifs_copy_folioq_to_iter(struct folio_queue *folioq, size_t data_size,
 {
 	for (; folioq; folioq = folioq->next) {
 		for (int s = 0; s < folioq_count(folioq); s++) {
-			struct folio *folio = folioq_folio(folioq, s);
-			size_t fsize = folio_size(folio);
-			size_t n, len = umin(fsize - skip, data_size);
+			struct folio *folio;
+			size_t fsize, n, len;
+
+			if (data_size == 0)
+				return 0;
+
+			folio = folioq_folio(folioq, s);
+			fsize = folio_size(folio);
+			len = umin(fsize - skip, data_size);
 
 			n = copy_folio_to_iter(folio, skip, len, iter);
 			if (n != len) {
@@ -4709,6 +4715,12 @@ cifs_copy_folioq_to_iter(struct folio_queue *folioq, size_t data_size,
 			data_size -= n;
 			skip = 0;
 		}
+	}
+
+	if (data_size != 0) {
+		cifs_dbg(VFS, "%s: short copy, %zu bytes missing\n",
+			 __func__, data_size);
+		return smb_EIO2(smb_eio_trace_rx_copy_to_iter, 0, data_size);
 	}
 
 	return 0;


### PR DESCRIPTION
cifs_copy_folioq_to_iter() copies a requested number of bytes from a folio queue into the destination iterator.  Since the encrypted SMB2 READ path was changed to pass the server-declared payload length (data_len) instead of the larger folioq buffer length, the caller can ask for fewer bytes than the folio queue holds.

In that case the helper continues walking the remaining folios after data_size has reached zero and calls copy_folio_to_iter() with len = 0, which is unnecessary work.

The helper also returns 0 (success) when the folio queue is exhausted before data_size bytes have been copied.  The caller has no way to distinguish that from a full copy and the reported transfer count ends up larger than the amount of data placed in the iterator.

Add an early exit when data_size reaches zero, and return an error when the folio queue is exhausted before all requested bytes have been copied.