### PR TITLE
smb: client: refresh allocation size after fallocate

### DIFF
--- a/fs/smb/client/smb2ops.c
+++ b/fs/smb/client/smb2ops.c
@@ -3663,9 +3663,12 @@ static long smb3_simple_falloc(struct file *file, struct cifs_tcon *tcon,
 	struct inode *inode;
 	struct cifsInodeInfo *cifsi;
 	struct cifsFileInfo *cfile = file->private_data;
+	struct smb2_file_all_info file_inf;
 	long rc = -EOPNOTSUPP;
 	unsigned int xid;
 	loff_t new_eof;
+	u64 asize;
+	int qrc;
 
 	xid = get_xid();
 
@@ -3700,6 +3703,17 @@ static long smb3_simple_falloc(struct file *file, struct cifs_tcon *tcon,
 		if (rc == 0) {
 			netfs_resize_file(&cifsi->netfs, new_eof, true);
 			cifs_setsize(inode, new_eof);
+
+			qrc = SMB2_query_info(xid, tcon, cfile->fid.persistent_fid,
+					      cfile->fid.volatile_fid, &file_inf);
+			spin_lock(&inode->i_lock);
+			if (qrc == 0) {
+				asize = le64_to_cpu(file_inf.AllocationSize);
+				inode->i_blocks = CIFS_INO_BLOCKS(asize);
+			} else {
+				cifsi->time = 0;
+			}
+			spin_unlock(&inode->i_lock);
 		}
 		goto out;
 	}


### PR DESCRIPTION
SMB3 fallocate extends EOF using FILE_END_OF_FILE_INFORMATION, but the server may or may not change the physical allocation size as a result. If the client maintains the old cached i_blocks value, swap activation (swapon) can incorrectly reject a fallocated file as having holes.

This causes swap-related xfstests to be skipped on CIFS mounts:

        generic/496         [not run] swapfiles are not supported

With Samba configured to ensure physical allocation:

        [scratch_share]
        strict allocate = yes

This patch allows the test to pass by refreshing the local i_blocks from the server's reported AllocationSize immediately after fallocate.

After a successful EOF-extending fallocate, query FILE_ALL_INFORMATION on the open handle and update i_blocks from the returned AllocationSize. If the query fails, leave the fallocate result unchanged and force a later attribute revalidation by setting cifsi->time to zero.