### PR TITLE
smb/client: refresh allocation size after fallocate

### DIFF
--- a/fs/smb/client/smb2ops.c
+++ b/fs/smb/client/smb2ops.c
@@ -3698,8 +3698,23 @@ static long smb3_simple_falloc(struct file *file, struct cifs_tcon *tcon,
 		rc = SMB2_set_eof(xid, tcon, cfile->fid.persistent_fid,
 				  cfile->fid.volatile_fid, cfile->pid, new_eof);
 		if (rc == 0) {
+			struct smb2_file_all_info file_inf;
+			u64 asize;
+			int qrc;
+
 			netfs_resize_file(&cifsi->netfs, new_eof, true);
 			cifs_setsize(inode, new_eof);
+
+			qrc = SMB2_query_info(xid, tcon, cfile->fid.persistent_fid,
+					      cfile->fid.volatile_fid, &file_inf);
+			spin_lock(&inode->i_lock);
+			if (qrc == 0) {
+				asize = le64_to_cpu(file_inf.AllocationSize);
+				inode->i_blocks = CIFS_INO_BLOCKS(asize);
+			} else {
+				cifsi->time = 0;
+			}
+			spin_unlock(&inode->i_lock);
 		}
 		goto out;
 	}


### PR DESCRIPTION
SMB3 fallocate extends EOF using FILE_END_OF_FILE_INFORMATION, but the server may also update the file's AllocationSize.  If the client keeps the old cached i_blocks value after fallocate, the swapfile hole check can still see:

        i_blocks * 512 < i_size

and reject the file as sparse.

This shows up in xfstests generic/496 as:

        generic/496         [not run] fallocated swap not supported here

After a successful EOF-extending fallocate, query FILE_ALL_INFORMATION on the open handle and update i_blocks from the returned AllocationSize. If the query fails, leave the fallocate result unchanged and force a later attribute revalidation by setting cifsi->time to zero.

With this client-side refresh, and with a server that really allocates the fallocated range, for example Samba configured with:

        [scratch_share]
        strict allocate = yes

generic/496 can pass the swapfile hole check.


Reviewed-by: ChenXiaoSong <chenxiaosong@kylinos.cn>