### PR TITLE
smb/client: fix security flag calculation when setting security infor…

### DIFF
--- a/fs/smb/client/cifsacl.c
+++ b/fs/smb/client/cifsacl.c
@@ -1738,7 +1738,7 @@ id_mode_to_cifs_acl(struct inode *inode, const char *path, __u64 *pnmode,
 			kuid_t uid, kgid_t gid)
 {
 	int rc = 0;
-	int aclflag = CIFS_ACL_DACL; /* default flag to set */
+	int aclflag = 0;
 	__u32 secdesclen = 0;
 	__u32 nsecdesclen = 0;
 	__u32 dacloffset = 0;
@@ -1833,6 +1833,12 @@ id_mode_to_cifs_acl(struct inode *inode, const char *path, __u64 *pnmode,
 			    mode_from_sid, id_from_sid, posix, &aclflag);
 
 	cifs_dbg(NOISY, "build_sec_desc rc: %d\n", rc);
+
+	if (aclflag == 0) {
+		cifs_dbg(FYI, "set_cifs_acl aclflag=0, no change mapped\n");
+		rc = 0;
+		goto id_mode_to_cifs_acl_exit;
+	}
 
 	if (ops->set_acl == NULL)
 		rc = -EOPNOTSUPP;


### PR DESCRIPTION
…mation

aclflag is of type MS-DTYP 2.4.7 SECURITY_INFORMATION which tells the server which parts of the security descriptor we're actually modifying (owner, group, dacl, sacl, ...).

When doing a chown() or chgrp() we don't want to force DACL_SECURITY_INFORMATION, build_sec_desc() does the proper flag calculation.