### PR TITLE
cifs: validate idmap key payload length

### DIFF
--- a/fs/smb/client/cifsacl.c
+++ b/fs/smb/client/cifsacl.c
@@ -68,6 +68,9 @@ cifs_idmap_key_instantiate(struct key *key, struct key_preparsed_payload *prep)
 {
 	char *payload;
 
+	if (prep->datalen > U16_MAX)
+		return -EINVAL;
+
 	/*
 	 * If the payload is less than or equal to the size of a pointer, then
 	 * an allocation here is wasteful. Just copy the data directly to the


### PR DESCRIPTION
The cifs.idmap key type stores its payload length in key->datalen, which is limited to U16_MAX.  Accepting a larger key payload truncates the recorded length and can make later users interpret the payload using inconsistent bounds.

Reject oversized preparsed payloads before allocating or copying them. This keeps key->datalen consistent with the stored data for both inline and separately allocated idmap payloads.