### PR TITLE
smb: client: free partially allocated transform folio queue

### DIFF
--- a/fs/smb/client/smb2ops.c
+++ b/fs/smb/client/smb2ops.c
@@ -4745,10 +4745,10 @@ smb3_init_transform_rq(struct TCP_Server_Info *server, int num_rqst,
 			size_t cur_size = 0;
 			rc = netfs_alloc_folioq_buffer(NULL, &buffer, &cur_size,
 						       size, GFP_NOFS);
+			new->rq_buffer = buffer;
 			if (rc < 0)
 				goto err_free;
 
-			new->rq_buffer = buffer;
 			iov_iter_folio_queue(&new->rq_iter, ITER_SOURCE,
 					     buffer, 0, 0, size);
 


### PR DESCRIPTION
netfs_alloc_folioq_buffer() may leave a partially allocated folio queue attached to the caller's buffer pointer when it returns an error.

smb3_init_transform_rq() stores the buffer in the request only after allocation succeeds, so the common error path cannot free a partial allocation. Store the buffer pointer before checking the return value so err_free releases it.


Reviewed-by: ChenXiaoSong <chenxiaosong@kylinos.cn>