### PR TITLE
smb: client: parallelize multichannel write issue

### DIFF
--- a/fs/smb/client/cifsglob.h
+++ b/fs/smb/client/cifsglob.h
@@ -582,7 +582,7 @@ struct smb_version_operations {
 	unsigned int (*wp_retry_size)(struct inode *);
 	/* get mtu credits */
 	int (*wait_mtu_credits)(struct TCP_Server_Info *, size_t,
-				size_t *, struct cifs_credits *);
+				size_t *, struct cifs_credits *, bool);
 	/* adjust previously taken mtu credits to request size */
 	int (*adjust_credits)(struct TCP_Server_Info *server,
 			      struct cifs_io_subrequest *subreq,
@@ -706,6 +706,7 @@ struct TCP_Server_Info {
 	bool terminate;
 	int credits;  /* send no more requests at once */
 	unsigned int max_credits; /* can override large 32000 default at mnt */
+	unsigned int queued;  /* number of requests queued to be sent on the wire */
 	unsigned int in_flight;  /* number of requests on the wire to server */
 	unsigned int max_in_flight; /* max number of requests that were on wire */
 	spinlock_t req_lock;  /* protect the two values above */
@@ -834,6 +835,8 @@ struct TCP_Server_Info {
 	char *leaf_fullpath;
 	bool dfs_conn:1;
 	char dns_dom[CIFS_MAX_DOMAINNAME_LEN + 1];
+
+	struct workqueue_struct *fio_wq;
 };
 
 static inline bool is_smb1(const struct TCP_Server_Info *server)
@@ -1498,6 +1501,7 @@ struct cifs_io_subrequest {
 	int				result;
 	bool				have_xid;
 	bool				replay;
+	bool				offloaded;
 	unsigned int			retries;	/* number of retries so far */
 	unsigned int			cur_sleep;	/* time to sleep before replay */
 	struct kvec			iov[2];

--- a/fs/smb/client/cifsproto.h
+++ b/fs/smb/client/cifsproto.h
@@ -112,7 +112,7 @@ int __smb_send_rqst(struct TCP_Server_Info *server, int num_rqst,
 int wait_for_free_request(struct TCP_Server_Info *server, const int flags,
 			  unsigned int *instance);
 int cifs_wait_mtu_credits(struct TCP_Server_Info *server, size_t size,
-			  size_t *num, struct cifs_credits *credits);
+			  size_t *num, struct cifs_credits *credits, bool offloaded);
 
 static inline int
 send_cancel(struct cifs_ses *ses, struct TCP_Server_Info *server,

--- a/fs/smb/client/connect.c
+++ b/fs/smb/client/connect.c
@@ -5,6 +5,7 @@
  *   Author(s): Steve French (sfrench@us.ibm.com)
  *
  */
+#include <linux/workqueue.h>
 #include <linux/fs.h>
 #include <linux/fs_context.h>
 #include <linux/net.h>
@@ -1722,6 +1723,8 @@ cifs_put_tcp_session(struct TCP_Server_Info *server, int from_reconnect)
 	else
 		cancel_delayed_work_sync(&server->reconnect);
 
+	destroy_workqueue(server->fio_wq);
+
 	/* For secondary channels, we pick up ref-count on the primary server */
 	if (SERVER_IS_CHAN(server))
 		cifs_put_tcp_session(server->primary_server, from_reconnect);
@@ -1746,6 +1749,7 @@ cifs_get_tcp_session(struct smb3_fs_context *ctx,
 		     struct TCP_Server_Info *primary_server)
 {
 	struct TCP_Server_Info *tcp_ses = NULL;
+	unsigned long chan_nr = 0;
 	int rc;
 
 	cifs_dbg(FYI, "UNC: %s\n", ctx->UNC);
@@ -1793,11 +1797,12 @@ cifs_get_tcp_session(struct smb3_fs_context *ctx,
 	tcp_ses->tcp_nodelay = ctx->sockopt_tcp_nodelay;
 	tcp_ses->rdma = ctx->rdma;
 	tcp_ses->in_flight = 0;
+	tcp_ses->queued = 0;
 	tcp_ses->max_in_flight = 0;
 	tcp_ses->credits = 1;
 	if (primary_server) {
 		spin_lock(&cifs_tcp_ses_lock);
-		++primary_server->srv_count;
+		chan_nr = ++primary_server->srv_count;
 		spin_unlock(&cifs_tcp_ses_lock);
 		tcp_ses->primary_server = primary_server;
 	}
@@ -1843,6 +1848,15 @@ cifs_get_tcp_session(struct smb3_fs_context *ctx,
 	tcp_ses->tcpStatus = CifsNew;
 	++tcp_ses->srv_count;
 	tcp_ses->echo_interval = ctx->echo_interval * HZ;
+
+	tcp_ses->fio_wq = alloc_ordered_workqueue("cifs_fio-%p-%lu",
+						  WQ_MEM_RECLAIM,
+						  tcp_ses->primary_server ? tcp_ses->primary_server : tcp_ses,
+						  chan_nr);
+	if (!tcp_ses->fio_wq) {
+		rc = -ENOMEM;
+		goto out_err_crypto_release;
+	}
 
 	if (tcp_ses->rdma) {
 #ifndef CONFIG_CIFS_SMB_DIRECT
@@ -1926,6 +1940,8 @@ out_err:
 		kfree(tcp_ses->leaf_fullpath);
 		if (tcp_ses->ssocket)
 			sock_release(tcp_ses->ssocket);
+		if (tcp_ses->fio_wq)
+			destroy_workqueue(tcp_ses->fio_wq);
 		kfree(tcp_ses);
 	}
 	return ERR_PTR(rc);

--- a/fs/smb/client/file.c
+++ b/fs/smb/client/file.c
@@ -38,6 +38,53 @@
 #include <trace/events/netfs.h>
 
 static int cifs_reopen_file(struct cifsFileInfo *cfile, bool can_flush);
+static void cifs_do_issue_write(struct netfs_io_subrequest *subreq);
+
+struct cifs_file_io_work {
+	struct work_struct work;
+	struct netfs_io_subrequest *subreq;
+};
+
+static void cifs_dequeue_in_flight(struct cifs_io_subrequest *wdata)
+{
+	struct TCP_Server_Info *server = wdata->server;
+
+	if (wdata->credits.value > 0) {
+		spin_lock(&server->req_lock);
+		server->in_flight++;
+		server->queued--;
+		if (server->in_flight > server->max_in_flight)
+			server->max_in_flight = server->in_flight;
+		spin_unlock(&server->req_lock);
+	}
+}
+
+static void cifs_issue_write_work_fn(struct work_struct *work)
+{
+	struct cifs_file_io_work *w = container_of(work, struct cifs_file_io_work, work);
+	struct cifs_io_subrequest *wdata =
+			container_of(w->subreq, struct cifs_io_subrequest, subreq);
+
+	cifs_dequeue_in_flight(wdata);
+	cifs_do_issue_write(w->subreq);
+	kfree(w);
+}
+
+static int cifs_offload_write(struct netfs_io_subrequest *subreq)
+{
+	struct cifs_io_subrequest *wdata =
+		container_of(subreq, struct cifs_io_subrequest, subreq);
+	struct cifs_file_io_work *w = kmalloc_obj(*w, GFP_NOFS);
+
+	if (!w)
+		return -ENOMEM;
+
+	w->subreq = subreq;
+	INIT_WORK(&w->work, cifs_issue_write_work_fn);
+	queue_work(wdata->server->fio_wq, &w->work);
+
+	return 0;
+}
 
 /*
  * Prepare a subrequest to upload to the server.  We need to allocate credits
@@ -49,10 +96,12 @@ static void cifs_prepare_write(struct netfs_io_subrequest *subreq)
 		container_of(subreq, struct cifs_io_subrequest, subreq);
 	struct cifs_io_request *req = wdata->req;
 	struct netfs_io_stream *stream = &req->rreq.io_streams[subreq->stream_nr];
+	struct cifs_ses *ses = tlink_tcon(req->cfile->tlink)->ses;
 	struct TCP_Server_Info *server;
 	struct cifsFileInfo *open_file = req->cfile;
 	struct cifs_sb_info *cifs_sb = CIFS_SB(wdata->rreq->inode->i_sb);
 	size_t wsize = req->rreq.wsize;
+	bool offload;
 	int rc;
 
 	if (!wdata->have_xid) {
@@ -78,8 +127,12 @@ retry:
 		}
 	}
 
+	spin_lock(&ses->chan_lock);
+	offload = ses->chan_count > 1;
+	spin_unlock(&ses->chan_lock);
+	wdata->offloaded = offload;
 	rc = server->ops->wait_mtu_credits(server, wsize, &stream->sreq_max_len,
-					   &wdata->credits);
+					   &wdata->credits, offload);
 	if (rc < 0) {
 		subreq->error = rc;
 		return netfs_prepare_write_failed(subreq);
@@ -108,7 +161,7 @@ retry:
 /*
  * Issue a subrequest to upload to the server.
  */
-static void cifs_issue_write(struct netfs_io_subrequest *subreq)
+static void cifs_do_issue_write(struct netfs_io_subrequest *subreq)
 {
 	struct cifs_io_subrequest *wdata =
 		container_of(subreq, struct cifs_io_subrequest, subreq);
@@ -142,6 +195,25 @@ fail:
 	goto out;
 }
 
+static void cifs_issue_write(struct netfs_io_subrequest *subreq)
+{
+	struct cifs_io_subrequest *wdata = container_of(subreq, struct cifs_io_subrequest, subreq);
+	int err;
+
+	if (!wdata->offloaded) {
+		cifs_do_issue_write(subreq);
+		return;
+	}
+
+	err = cifs_offload_write(subreq);
+	if (err) {
+		trace_netfs_sreq(subreq, netfs_sreq_trace_fail);
+		cifs_dequeue_in_flight(wdata);
+		add_credits_and_wake_if(wdata->server, &wdata->credits, 0);
+		cifs_write_subrequest_terminated(wdata, err);
+	}
+}
+
 static void cifs_netfs_invalidate_cache(struct netfs_io_request *wreq)
 {
 	cifs_invalidate_cache(wreq->inode, 0);
@@ -173,7 +245,7 @@ static int cifs_prepare_read(struct netfs_io_subrequest *subreq)
 				     tlink_tcon(req->cfile->tlink));
 
 	rc = server->ops->wait_mtu_credits(server, cifs_sb->ctx->rsize,
-					   &size, &rdata->credits);
+					   &size, &rdata->credits, false);
 	if (rc)
 		return rc;
 

--- a/fs/smb/client/smb2ops.c
+++ b/fs/smb/client/smb2ops.c
@@ -244,7 +244,8 @@ smb2_get_credits(struct mid_q_entry *mid)
 
 static int
 smb2_wait_mtu_credits(struct TCP_Server_Info *server, size_t size,
-		      size_t *num, struct cifs_credits *credits)
+		      size_t *num, struct cifs_credits *credits,
+		      bool offloaded)
 {
 	int rc = 0;
 	unsigned int scredits, in_flight;
@@ -289,7 +290,13 @@ smb2_wait_mtu_credits(struct TCP_Server_Info *server, size_t size,
 				DIV_ROUND_UP(*num, SMB2_MAX_BUFFER_SIZE);
 			credits->instance = server->reconnect_instance;
 			server->credits -= credits->value;
-			server->in_flight++;
+
+			/* steal the credits, but don't mark in_flight yet */
+			if (offloaded)
+				server->queued++;
+			else
+				server->in_flight++;
+
 			if (server->in_flight > server->max_in_flight)
 				server->max_in_flight = server->in_flight;
 			break;

--- a/fs/smb/client/transport.c
+++ b/fs/smb/client/transport.c
@@ -629,7 +629,7 @@ wait_for_compound_request(struct TCP_Server_Info *server, int num,
 
 int
 cifs_wait_mtu_credits(struct TCP_Server_Info *server, size_t size,
-		      size_t *num, struct cifs_credits *credits)
+		      size_t *num, struct cifs_credits *credits, bool offloaded)
 {
 	*num = size;
 	credits->value = 0;
@@ -847,8 +847,8 @@ struct TCP_Server_Info *cifs_pick_channel(struct cifs_ses *ses)
 		 * taking the lock could help reduce wait time, which is
 		 * important for this function
 		 */
-		if (server->in_flight < min_in_flight) {
-			min_in_flight = server->in_flight;
+		if (server->in_flight + server->queued < min_in_flight) {
+			min_in_flight = server->in_flight + server->queued;
 			index = cur;
 		}
 	}


### PR DESCRIPTION
The netfs writeback path issues write subrequests through the filesystem issue_write() callback. For multichannel, those subrequests may target different channels, but the issue callback is still entered serially by the netfs issuing context.

As a result, while one channel is running the write issue path, write subrequests for other channels may be left waiting to be issued. This can limit multichannel writeback throughput because the channels are not kept busy independently.

For multichannel sessions, queue the existing write issue path to a workqueue. This lets the netfs issuing context return quickly and continue issuing subsequent write subrequests for other channels. Single-channel sessions keep the existing synchronous issue path.

Preliminary fio testing showed improvments in throughput by up to 2.5x in small-file writeback with larger dirty limits (1g/256m), gives 1.4x improvement for 1GiB writes with larger dirty limits, and is neutral when dirty limits keep the pipeline shallow (4m/1m).